### PR TITLE
Add overflow protection for size_t multiplications

### DIFF
--- a/include/cds/common.h
+++ b/include/cds/common.h
@@ -2,11 +2,16 @@
 #define CDS_COMMON_H
 
 #include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
 
 /* Return codes */
 #define CDS_OK         0
 #define CDS_ERR_ALLOC -1
 #define CDS_ERR_INDEX -2
 #define CDS_ERR_NULL  -3
+
+static inline bool is_sizet_overflow(size_t a, size_t b) { return a != 0 && b > SIZE_MAX/a; }
 
 #endif /* CDS_COMMON_H */

--- a/src/vector.c
+++ b/src/vector.c
@@ -1,5 +1,6 @@
 #include "cds/vector.h"
 #include "cds/common.h"
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include "cds/algo.h"
@@ -16,6 +17,10 @@ struct cds_vector {
 cds_vector *cds_vector_create(size_t size) {
   cds_vector *v = malloc(sizeof(struct cds_vector));
   if (!v) return NULL;
+  if (is_sizet_overflow(size, INITIAL_CAPACITY)) {
+    free(v);
+    return NULL;
+  }
   v->data = malloc(size * INITIAL_CAPACITY);
   if (!v->data) {
     free(v);
@@ -43,6 +48,7 @@ cds_vector *cds_vector_from(const void *src, size_t n, size_t size) {
 int cds_vector_reserve(cds_vector *v, size_t n) {
   if (!v || !v->data) return CDS_ERR_NULL;
   if (n <= v->capacity) return CDS_OK;
+  if (is_sizet_overflow(n, v->element_size)) return CDS_ERR_ALLOC;
   void *new_data = realloc(v->data, n * v->element_size);
   if (!new_data) return CDS_ERR_ALLOC;
   v->data = new_data;
@@ -71,6 +77,9 @@ int cds_vector_set(cds_vector *v, size_t index, const void *element) {
 int cds_vector_push(cds_vector *v, const void *element) {
   if (!v || !v->data || !element) return CDS_ERR_NULL;
   if (v->size == v->capacity) {
+    if (is_sizet_overflow(2, v->capacity) ||
+        is_sizet_overflow((v->capacity * 2), v->element_size))
+      return CDS_ERR_ALLOC;
     void *new_data = realloc(v->data, v->capacity * 2 * v->element_size);
     if (!new_data) return CDS_ERR_ALLOC;
     v->data = new_data;

--- a/tests/main.c
+++ b/tests/main.c
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include "cds/common.h"
 #include "cds/vector.h"
@@ -10,10 +11,16 @@ int cmp_int(const void *a, const void *b)
 int main(void)
 {
     printf("=== cds_vector_create ===\n");
+    cds_vector *invalid_v = cds_vector_create(SIZE_MAX);
+    if (invalid_v) {
+      printf("FAIL: cds_vector_create should not create a vector with invalid size (size=%zu * %d)\n", SIZE_MAX, 8);
+      return 1;
+    }
+    printf("OK: vector with invalid size cannot be created (size=%zu * %d)\n", SIZE_MAX, 8);
     cds_vector *v = cds_vector_create(sizeof(int));
     if (!v) {
-        printf("FAIL: cds_vector_create returned NULL\n");
-        return 1;
+      printf("FAIL: cds_vector_create returned NULL\n");
+      return 1;
     }
     printf("OK: vector created (size=%zu, capacity=%zu)\n",
            cds_vector_size(v), cds_vector_capacity(v));
@@ -22,16 +29,16 @@ int main(void)
     int values[] = {42, 7, 23, 1, 99, 15, 8, 56, 3, 31};
     size_t n = sizeof(values) / sizeof(values[0]);
     for (size_t i = 0; i < n; i++) {
-        int result = cds_vector_push(v, &values[i]);
-        printf("push %d -> %s\n", values[i], result == CDS_OK ? "OK" : "FAIL");
+      int result = cds_vector_push(v, &values[i]);
+      printf("push %d -> %s\n", values[i], result == CDS_OK ? "OK" : "FAIL");
     }
     printf("after pushes: size=%zu, capacity=%zu\n",
            cds_vector_size(v), cds_vector_capacity(v));
 
     printf("\n=== cds_vector_get ===\n");
     for (size_t i = 0; i < cds_vector_size(v); i++) {
-        int *val = cds_vector_get(v, i);
-        if (val) printf("  v[%zu] = %d\n", i, *val);
+      int *val = cds_vector_get(v, i);
+      if (val) printf("  v[%zu] = %d\n", i, *val);
     }
     int *out_of_bounds = cds_vector_get(v, 999);
     printf("get out of bounds -> %s\n", out_of_bounds == NULL ? "OK (NULL)" : "FAIL");
@@ -47,7 +54,14 @@ int main(void)
     cds_vector_set(v, 0, &values[0]);
 
     printf("\n=== cds_vector_reserve ===\n");
-    int res_result = cds_vector_reserve(v, 64);
+    int res_result = cds_vector_reserve(v, SIZE_MAX);
+    if (res_result == 0) {
+      printf("reserve SIZE_MAX should not be valid\n");
+      return 1;
+    }
+    printf("reserve SIZE_MAX failed as expected\n");
+      
+    res_result = cds_vector_reserve(v, 64);
     printf("reserve 64 -> %s (capacity=%zu)\n",
            res_result == CDS_OK ? "OK" : "FAIL", cds_vector_capacity(v));
     res_result = cds_vector_reserve(v, 8);
@@ -68,16 +82,16 @@ int main(void)
     printf("\n=== cds_vector_sort ===\n");
     printf("before sort: ");
     for (size_t i = 0; i < cds_vector_size(v); i++) {
-        int *val = cds_vector_get(v, i);
-        if (val) printf("%d ", *val);
+      int *val = cds_vector_get(v, i);
+      if (val) printf("%d ", *val);
     }
     printf("\n");
     int sort_result = cds_vector_sort(v, cmp_int);
     printf("sort -> %s\n", sort_result == CDS_OK ? "OK" : "FAIL");
     printf("after sort:  ");
     for (size_t i = 0; i < cds_vector_size(v); i++) {
-        int *val = cds_vector_get(v, i);
-        if (val) printf("%d ", *val);
+      int *val = cds_vector_get(v, i);
+      if (val) printf("%d ", *val);
     }
     printf("\n");
 
@@ -95,10 +109,10 @@ int main(void)
     printf("\n=== cds_vector_pop ===\n");
     int popped;
     if (cds_vector_pop(v, &popped) == CDS_OK)
-        printf("popped: %d\n", popped);
+      printf("popped: %d\n", popped);
     printf("after pop: size=%zu\n", cds_vector_size(v));
     if (cds_vector_pop(v, NULL) == CDS_OK)
-        printf("pop with NULL out: OK (size=%zu)\n", cds_vector_size(v));
+      printf("pop with NULL out: OK (size=%zu)\n", cds_vector_size(v));
 
     printf("\n=== cds_vector_destroy ===\n");
     cds_vector_destroy(v);
@@ -108,15 +122,15 @@ int main(void)
     int src[] = {10, 20, 30, 40, 50};
     cds_vector *v2 = cds_vector_from(src, 5, sizeof(int));
     if (!v2) {
-        printf("FAIL: cds_vector_from returned NULL\n");
-        return 1;
+      printf("FAIL: cds_vector_from returned NULL\n");
+      return 1;
     }
     printf("OK: vector from array (size=%zu, capacity=%zu)\n",
            cds_vector_size(v2), cds_vector_capacity(v2));
     printf("contents: ");
     for (size_t i = 0; i < cds_vector_size(v2); i++) {
-        int *val = cds_vector_get(v2, i);
-        if (val) printf("%d ", *val);
+      int *val = cds_vector_get(v2, i);
+      if (val) printf("%d ", *val);
     }
     printf("\n");
     printf("is_sorted -> %s\n", cds_vector_is_sorted(v2, cmp_int) ? "true" : "false");


### PR DESCRIPTION
## Summary
- Add `is_sizet_overflow()` helper in `common.h` to detect arithmetic overflow before passing products to `malloc`/`realloc`
- Guard all allocation paths in `vector.c`: `create`, `reserve`, and `push`
- Add tests verifying that `SIZE_MAX` inputs are rejected

## Details
Expressions like `n * element_size` can wrap around on large values, causing a small allocation followed by buffer overflow. The fix checks `b > SIZE_MAX / a` before every multiplication that feeds into an allocator.

Protected call sites:
- `cds_vector_create`: `size * INITIAL_CAPACITY`
- `cds_vector_reserve`: `n * v->element_size`
- `cds_vector_push`: `v->capacity * 2 * v->element_size` (two chained checks with short-circuit `||`)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)